### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for thanos-acm-214

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -23,7 +23,8 @@ COPY --from=builder /go/bin/thanos /bin/thanos
 ENTRYPOINT [ "/bin/thanos" ]
 
 LABEL com.redhat.component="thanos" \
-  name="thanos" \
+  name="rhacm2/thanos-rhel9" \
+  cpe="cpe:/a:redhat:acm:2.14::el9" \
   summary="thanos" \
   io.openshift.expose-services="" \
   io.openshift.tags="data,images" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
