### PR TITLE
Add repository url label to container images

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -23,6 +23,7 @@ COPY --from=builder /go/bin/thanos /bin/thanos
 ENTRYPOINT [ "/bin/thanos" ]
 
 LABEL com.redhat.component="thanos" \
+  url="https://github.com/stolostron/thanos" \
   name="thanos" \
   summary="thanos" \
   io.openshift.expose-services="" \


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275
All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** release-2.15

**Components affected:** thanos

**Branch details:** thanos (branch: release-2.15)

**Label added:**
- url: https://github.com/stolostron/thanos

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
