### PR TITLE
chore: update PR guidance files (2026-04-21)

### DIFF
--- a/.cve-fix/examples.md
+++ b/.cve-fix/examples.md
@@ -1,14 +1,15 @@
-<!-- last-analyzed: 2026-04-16 | cve-merged: 6 -->
+<!-- last-analyzed: 2026-04-21 | cve-merged: 6 | cve-closed: 0 | WARNING: limited-data since last analysis — new patterns based on 1 open PR + 2 commits, verify before relying on additions -->
 
 ## Titles
 - `Security: Fix CVE-YYYY-XXXXX (<package>)` (3/35 merged PRs)
-  - e.g. `Security: Fix CVE-2026-33186 (grpc-go)`
   - e.g. `Security: Fix CVE-2026-33186 (grpc-go)`
 - `Other CVE title format` (2/35 merged PRs)
   - e.g. `fix: [release-2.10] CVE-2023-45288 ensure golang/x/net is 0.23+`
   - e.g. `CVE-2023-45288 ensure golang/x/net is 0.23+`
 - `Bump <pkg> from X to Y to fix CVE-YYYY-XXXXX` (1/35 merged PRs)
   - e.g. `Bump google.golang.org/grpc to v1.79.3 to fix CVE-2026-33186`
+- `fix(cve): CVE-YYYY-XXXXX - <package>` — alternate format used by CVE Fixer workflow (1 open PR + 1 commit)
+  - e.g. `fix(cve): CVE-2025-13465 - lodash`
 
 ## Branches
 - `fix/cve-<id>-<pkg>-<branch>-attempt-N` (4/35 merged PRs)
@@ -18,17 +19,24 @@
   - e.g. `dependabot/go_modules/golang.org/x/crypto-0.35.0`
   - e.g. `dependabot/go_modules/github.com/golang-jwt/jwt/v5-5.2.2`
 
-## Files
+## Files — Go ecosystem
 - `go.mod` + `go.sum` always change together for Go dependency updates
 - `Dockerfile` / `Containerfile.operator` may also be updated (Go version bumps)
+
+## Files — npm/JS ecosystem (pkg/ui)
+- `pkg/ui/react-app/package.json` + `pkg/ui/react-app/package-lock.json` change together for npm CVEs (1 open PR)
+- `pkg/ui/static/react/static/js/*.map` updated (JS source maps rebuilt)
 
 ## Co-upgrades
 - When bumping a Go dependency, always run `go mod tidy` to update `go.sum`
 - Go version bumps (`go.mod` directive) often require updating `Dockerfile` / `Containerfile.operator`
+- For transitive npm deps (e.g. lodash): use `overrides.<package>: "^<version>"` in `package.json` (1 open PR)
 
 ## PR Description
 - Include CVE ID, severity, and affected package in description
+- Include impact description, vulnerable version range, and fixed version
 - Reference the target branch (e.g. `release-2.16`) when targeting non-default branches
+- Include Jira reference in format: `Resolves: ACM-XXXXX` (1 open PR + commit)
 - Include test results section
 - For multi-branch fixes, create separate PRs per branch (not a single PR)
 

--- a/.cve-fix/examples.md
+++ b/.cve-fix/examples.md
@@ -25,7 +25,13 @@
 
 ## Files — npm/JS ecosystem (pkg/ui)
 - `pkg/ui/react-app/package.json` + `pkg/ui/react-app/package-lock.json` change together for npm CVEs (1 open PR)
-- `pkg/ui/static/react/static/js/*.map` updated (JS source maps rebuilt)
+- `pkg/ui/static/react/` tree updated after rebuild (JS bundles, source maps, assets)
+
+## Build steps — npm/JS ecosystem (must run in order)
+1. `cd pkg/ui/react-app && npm ci` — installs deps resolving the override
+2. `scripts/build-react-app.sh` — runs `PUBLIC_URL=. npm run build` and moves output to `pkg/ui/static/react/`
+
+Or equivalently: `make react-app` (runs both steps via Makefile)
 
 ## Co-upgrades
 - When bumping a Go dependency, always run `go mod tidy` to update `go.sum`


### PR DESCRIPTION
## Summary

Updates `.cve-fix/examples.md` with new patterns observed since the last analysis (2026-04-16).

## What Changed

### CVE Guidance (.cve-fix/examples.md)
- New rule: Alternate title format `fix(cve): CVE-YYYY-XXXXX - package` (used by CVE Fixer workflow)
- New rule: npm/JS ecosystem file co-changes — `pkg/ui/react-app/package.json`, `pkg/ui/react-app/package-lock.json`, and `pkg/ui/static/react/static/js/*.map` for npm CVEs
- New rule: npm override strategy — use `overrides.<package>` in `package.json` for transitive deps
- Updated: PR Description guidance expanded with impact, vulnerable version range, fixed version, and Jira `Resolves: ACM-XXXXX` format
- Updated: `last-analyzed` date to 2026-04-21

## New PRs Analyzed
- CVE PRs: 1 open PR (#341 CVE-2025-13465 lodash) + 2 commit fallbacks since 2026-04-16
- Bugfix PRs: 0

> ⚠️ **Limited data**: No new merged CVE PRs since last analysis. Additions are based on 1 open PR + commit fallback — verify patterns before relying on them.

---
Generated by PR Guidance Generator workflow