### PR TITLE
[release-5.0] Fix for CVE-2026-33186

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -323,7 +323,7 @@ replace (
 
 	github.com/vimeo/galaxycache => github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e
 
-	google.golang.org/grpc => github.com/thanos-community/grpc-go v0.0.0-20251106112228-b9020406f781
+	google.golang.org/grpc => github.com/thanos-community/grpc-go v0.0.0-20260331083222-a7315f1dfb76
 
 	// Overriding to use latest commit.
 	gopkg.in/alecthomas/kingpin.v2 => github.com/alecthomas/kingpin v1.3.8-0.20210301060133-17f40c25f497

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	golang.org/x/sync v0.19.0
 	golang.org/x/text v0.33.0
 	golang.org/x/time v0.13.0
-	google.golang.org/grpc v1.79.3
+	google.golang.org/grpc v1.76.0
 	google.golang.org/grpc/examples v0.0.0-20250407062114-b368379ef8f6
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -3888,8 +3888,8 @@ github.com/tencentyun/cos-go-sdk-v5 v0.7.66 h1:O4O6EsozBoDjxWbltr3iULgkI7WPj/BFN
 github.com/tencentyun/cos-go-sdk-v5 v0.7.66/go.mod h1:8+hG+mQMuRP/OIS9d83syAvXvrMj9HhkND6Q1fLghw0=
 github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e h1:f1Zsv7OAU9iQhZwigp50Yl38W10g/vd5NC8Rdk1Jzng=
 github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e/go.mod h1:jXcofnrSln/cLI6/dhlBxPQZEEQHVPCcFaH75M+nSzM=
-github.com/thanos-community/grpc-go v0.0.0-20251106112228-b9020406f781 h1:e9c72LR6jBSpBjjBRjqeoNp1qQLZQqMyeHzNqvou5NE=
-github.com/thanos-community/grpc-go v0.0.0-20251106112228-b9020406f781/go.mod h1:YnIHHmJ2ND31zdEiJmIw5W6dtr05o2clL82wnWwFnn0=
+github.com/thanos-community/grpc-go v0.0.0-20260331083222-a7315f1dfb76 h1:RheGORM3blydQlRgttQK1rEk9fFXqsupByS4yo+hsUE=
+github.com/thanos-community/grpc-go v0.0.0-20260331083222-a7315f1dfb76/go.mod h1:YnIHHmJ2ND31zdEiJmIw5W6dtr05o2clL82wnWwFnn0=
 github.com/thanos-io/objstore v0.0.0-20250804093838-71d60dfee488 h1:khBsQLLRoF1KzXgTlwFZa6mC32bwYUUAu/AeP49V7UM=
 github.com/thanos-io/objstore v0.0.0-20250804093838-71d60dfee488/go.mod h1:uDHLkMKOGDAnlN75EAz8VrRzob1+VbgYSuUleatWuF0=
 github.com/thanos-io/promql-engine v0.0.0-20260119085929-dd5223783674 h1:C5yBEuIZCaeLh90lcUGfnGepmwDfGGYLu6+w7RxR7og=


### PR DESCRIPTION
The commit reverted here, bumps the dependency, however it is later "replaced", and as a result, has no effect.

This picks the upstream PR, which updated the replace statement, with the updated Thanos go-gprc fork which has the fix.