### PR TITLE
ci: bump e2e-kind Go version to 1.26.x

### DIFF
--- a/.github/workflows/e2e-stolostron.yaml
+++ b/.github/workflows/e2e-stolostron.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go.
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
 
       - uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
         with:


### PR DESCRIPTION
## Changes

bump e2e-kind Go version to 1.26.x
