### PR TITLE
fix: add USER 1001 to Dockerfile.prow to fix e2e-kind runAsNonRoot failure

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -20,6 +20,8 @@ LABEL maintainer="The ACM Thanos maintainers"
 
 COPY --from=builder /go/bin/thanos /bin/thanos
 
+USER 1001
+
 ENTRYPOINT [ "/bin/thanos" ]
 
 LABEL com.redhat.component="thanos" \

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -16,4 +16,6 @@ COPY --from=builder /go/bin/thanos /bin/thanos
 
 RUN microdnf update -y && microdnf clean all
 
+USER 1001
+
 ENTRYPOINT [ "/bin/thanos" ]


### PR DESCRIPTION
## Summary

- **CI fix**: Add `USER 1001` to `Dockerfile.prow` — fixes `CreateContainerConfigError` blocking all e2e-kind CI tests after observatorium-operator [PR #449](https://github.com/stolostron/observatorium-operator/pull/449) added `runAsNonRoot: true`
- **Consistency fix**: Add `USER 1001` to `Containerfile.operator` — same latent bug found during investigation, currently masked by OpenShift SCC

## Problem

`Dockerfile.prow` is missing a `USER` directive. The `ubi9/ubi-minimal` base image defaults to UID 0 (root). After observatorium-operator [PR #449](https://github.com/stolostron/observatorium-operator/pull/449) added `runAsNonRoot: true` to the pod security context, all Thanos pods fail in KinD CI with:

```
CreateContainerConfigError: container has runAsNonRoot and image will run as root
```

This is **Bug 2** in the e2e-kind failure chain — exposed after [PR #450](https://github.com/stolostron/observatorium-operator/pull/450) fixed Bug 1 (containerd rejecting `runAsGroup` without `runAsUser`).

### Failure chain

1. MCO sets `SecurityContext: {}` (empty) on the Observatorium CR
2. observatorium-operator merges with `basePodSecurityContext`: `{ runAsNonRoot: true }` — no `runAsUser`
3. kube-thanos templates create pods with `runAsNonRoot: true`, no `runAsUser`
4. kubelet's `verifyRunAsNonRoot`: no `runAsUser` in spec → inspect image UID → UID 0 (from `Dockerfile.prow`) → **REJECT**
5. On OpenShift: SCC `MustRunAsRange` injects a non-root UID before kubelet  checks → bug is invisible in production

### Additional finding: `Containerfile.operator`

While investigating the CI failure, `Containerfile.operator` (used by Konflux/RHTAP for production operator builds) was found to have the same missing `USER` directive. This is currently masked on OpenShift by SCC `MustRunAsRange` which injects a namespace-scoped UID, but would fail on vanilla Kubernetes with `runAsNonRoot: true`.

### Dockerfile inconsistency (before this PR)

| Dockerfile | USER directive | Used by | Status |
|---|---|---|---|
| `Dockerfile` | `USER 1001` | Upstream/local builds | OK |
| `Dockerfile.multi-arch` | `USER 1001` | Multi-arch builds | OK |
| **`Dockerfile.prow`** | **NONE (UID 0)** | **Prow CI / SNAPSHOT builds** | **Fixed — CI blocker** |
| **`Containerfile.operator`** | **NONE (UID 0)** | **Konflux / operator builds** | **Fixed — consistency** |

## Fix

### Commit 1: `Dockerfile.prow` (CI blocker fix)

Adds `USER 1001` before `ENTRYPOINT`. This directly unblocks e2e-kind CI:
- Image UID changes from 0 → 1001
- kubelet `verifyRunAsNonRoot` passes (non-root UID + `runAsNonRoot: true`)

### Commit 2: `Containerfile.operator` (consistency fix)

Adds `USER 1001` before `ENTRYPOINT`. Same latent bug found during
investigation — currently masked by OpenShift SCC `MustRunAsRange` which
injects a namespace-scoped UID. Fixed for defense-in-depth and consistency
with all other thanos and MCO component Dockerfiles.

### Platform behavior (both files)

| Platform | Behavior |
|----------|----------|
| **KinD/containerd** | Image UID = 1001 → kubelet `verifyRunAsNonRoot` passes |
| **OpenShift** | SCC overrides to namespace UID → passes (unchanged) |
| **Kubernetes** | Non-root UID satisfies `runAsNonRoot: true` → passes |

## References
- kubelet source: [`verifyRunAsNonRoot`](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/security_context_others.go) checks image UID when no `runAsUser` in spec
- observatorium-operator [PR #449](https://github.com/stolostron/observatorium-operator/pull/449) — added security hardening (exposed this latent bug)
- observatorium-operator [PR #450](https://github.com/stolostron/observatorium-operator/pull/450) — fixed Bug 1 (runAsGroup without runAsUser)