### PR TITLE
fix: patch CVE-2026-42151 in github.com/prometheus/prometheus [release-2.14] (minimal)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -287,6 +287,10 @@ replace (
 	// Required by Cortex https://github.com/cortexproject/cortex/pull/3051.
 	github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
 
+	// Patched fork based on v0.55.1 with fix cherry-picked from upstream prometheus/prometheus#18587.
+	// Ref: CVE-2026-42151 (GHSA-wg65-39gg-5wfj)
+	github.com/prometheus/prometheus => github.com/stolostron/prometheus v0.0.0-20260805153507-383a8f4f8330
+
 	// Pin kuberesolver/v5 to support new grpc version. Need to upgrade kuberesolver version on weaveworks/common.
 	github.com/sercand/kuberesolver/v4 => github.com/sercand/kuberesolver/v5 v5.1.1
 

--- a/go.sum
+++ b/go.sum
@@ -2179,8 +2179,6 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/prometheus/prometheus v0.55.1-0.20241102120812-a6fd22b9d2c8 h1:hCxAh6+hxwy7dqUPE5ndnilMeCWrqQkJVjPDXtiYRVo=
-github.com/prometheus/prometheus v0.55.1-0.20241102120812-a6fd22b9d2c8/go.mod h1:GGS7QlWKCqCbcEzWsVahYIfQwiGhcExkarHyLJTsv6I=
 github.com/redis/rueidis v1.0.45-alpha.1 h1:69Bu1l7gVC/qDYuGGwMwGg2rjOjSyxESol/Zila62gY=
 github.com/redis/rueidis v1.0.45-alpha.1/go.mod h1:q7BfhDaPt7xxwy2nv2RqQO12/mmHflDjebpcNwWFjms=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
@@ -2230,6 +2228,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/stolostron/grpc-go v1.63.2-patch-1 h1:XzqIwKP+q6BKsiJ/VB3OWEEfHuiRmH77lnLY1uqJGhI=
 github.com/stolostron/grpc-go v1.63.2-patch-1/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDomNkRA=
+github.com/stolostron/prometheus v0.0.0-20260805153507-383a8f4f8330 h1:JTtm2wgflYAeQKQnE4VsEratAzUtGqlGfa3NnuL5O8g=
+github.com/stolostron/prometheus v0.0.0-20260805153507-383a8f4f8330/go.mod h1:GGS7QlWKCqCbcEzWsVahYIfQwiGhcExkarHyLJTsv6I=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=


### PR DESCRIPTION
## Summary

* Patches **CVE-2026-42151** (GHSA-wg65-39gg-5wfj) — Prometheus Azure AD remote write OAuth `client_secret` exposed via the `/-/config` API endpoint.
* Uses a `replace` directive in `go.mod` to point `github.com/prometheus/prometheus` to stolostron/prometheus at the `cve-2026-42151/v0.55.1` branch (commit 383a8f4f), which contains the upstream fix (prometheus/prometheus#18587) cherry-picked onto the exact commit thanos release-2.14 uses.
* Follows the same minimal approach used on release-2.17 (PR #369).

### What the fix does

Changes `ClientSecret` in `OAuthConfig` (`storage/remote/azuread/azuread.go`) from `string` to `config.Secret`, so the Azure AD OAuth client secret is redacted as `<secret>` when served through the `/-/config` HTTP API endpoint.

### Why this approach

The stolostron/prometheus `cve-2026-42151/v0.55.1` branch:
- Is based on the **exact commit** thanos release-2.14 uses (`a6fd22b9d2c8`)
- Only modifies `azuread.go` and `azuread_test.go` (3 lines of code)
- Does **not** change `go.mod` in the prometheus fork, so Go MVS pulls in zero new transitive dependencies

This results in a **go.mod + go.sum only** change in thanos — no code changes, no dependency pins, no interface fixes needed.

### Supersedes

This PR supersedes #378 which took a heavier approach using the full stolostron/prometheus release-2.14 branch (requiring go-control-plane pins, larger dependency bumps, and go vet/test fixes).

### Verification

* `go mod tidy` — passes cleanly
* `go build ./...` — compiles cleanly
* `go mod verify` — all modules verified
* `go vet ./...` — identical pre-existing issues as base branch (Seek signature warnings), zero new issues

### Jira

* ACM-36220

## Test plan

* `go mod tidy` passes without errors
* `go build ./...` succeeds
* `go mod verify` passes
* `go vet ./...` shows no new issues vs. base branch
* CI pipeline passes

Made with [Cursor](https://cursor.com)