### PR TITLE
fix: patch CVE-2026-42151 in github.com/prometheus/prometheus [release-2.13] (minimal)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -276,6 +276,10 @@ replace (
 	// Required by Cortex https://github.com/cortexproject/cortex/pull/3051.
 	github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
 
+	// Patched fork based on v0.51.1-20240325 with fix cherry-picked from upstream prometheus/prometheus#18587.
+	// Ref: CVE-2026-42151 (GHSA-wg65-39gg-5wfj)
+	github.com/prometheus/prometheus => github.com/stolostron/prometheus v0.0.0-20260809205240-e1bde220dac8
+
 	github.com/vimeo/galaxycache => github.com/thanos-community/galaxycache v0.0.0-20211122094458-3a32041a1f1e
 
 	// Override due to https://github.com/weaveworks/common/issues/239

--- a/go.sum
+++ b/go.sum
@@ -1462,8 +1462,6 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
-github.com/prometheus/prometheus v0.51.1-0.20240325140356-78c0fd2f4d75 h1:kIGJHrZqxmiSIidDXlmHISDNtr4dSTqIC6vjxbYsH1I=
-github.com/prometheus/prometheus v0.51.1-0.20240325140356-78c0fd2f4d75/go.mod h1:FguQG8pCICrSpHA2pwizwV5FxGNTUBSZED/wMoZwVfY=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redis/rueidis v1.0.14-go1.18 h1:dGir5z8w8X1ex7JWO/Zx2FMBrZgQ8Yjm+lw9fPLSNGw=
 github.com/redis/rueidis v1.0.14-go1.18/go.mod h1:HGekzV3HbmzFmRK6j0xic8Z9119+ECoGMjeN1TV1NYU=
@@ -1521,6 +1519,8 @@ github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stolostron/prometheus v0.0.0-20260809205240-e1bde220dac8 h1:OnoR9yN40e1TbnVxctEC1sBKKhmHZANel9UussRjzQs=
+github.com/stolostron/prometheus v0.0.0-20260809205240-e1bde220dac8/go.mod h1:FguQG8pCICrSpHA2pwizwV5FxGNTUBSZED/wMoZwVfY=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=


### PR DESCRIPTION
## Summary

* Patches **CVE-2026-42151** (GHSA-wg65-39gg-5wfj) — Prometheus Azure AD remote write OAuth `client_secret` exposed via the `/-/config` API endpoint.
* Uses a `replace` directive in `go.mod` to point `github.com/prometheus/prometheus` to stolostron/prometheus at the `cve-2026-42151/v0.51.1-20240325` branch (commit e1bde220dac8), which contains the upstream fix (prometheus/prometheus#18587) cherry-picked onto the exact commit thanos release-2.13 uses.
* Follows the same minimal approach used on release-2.17 (PR #369) and release-2.14 (PR #384).

### What the fix does

Changes `ClientSecret` in `OAuthConfig` (`storage/remote/azuread/azuread.go`) from `string` to `config.Secret`, so the Azure AD OAuth client secret is redacted as `<secret>` when served through the `/-/config` HTTP API endpoint.

### Why this approach

The stolostron/prometheus `cve-2026-42151/v0.51.1-20240325` branch:
- Is based on the **exact commit** thanos release-2.13 uses (`78c0fd2f4d75`)
- Only modifies `azuread.go` and `azuread_test.go` (3 lines of code)
- Does **not** change `go.mod` in the prometheus fork, so Go MVS pulls in zero new transitive dependencies

This results in a **go.mod + go.sum only** change in thanos — no code changes, no dependency pins, no interface fixes needed.

### Supersedes

This PR supersedes #379 which took a heavier approach using the full stolostron/prometheus release-2.13 branch (requiring prometheus/common pins, otlptracegrpc pins, chunk interface changes, and test signature fixes).

### Verification

* `go mod tidy` — passes cleanly
* `go build ./...` — compiles cleanly
* `go mod verify` — all modules verified
* `go vet ./...` — identical pre-existing issues as base branch (Seek signature warnings), zero new issues

### Jira

* ACM-36204

## Test plan

* `go mod tidy` passes without errors
* `go build ./...` succeeds
* `go mod verify` passes
* `go vet ./...` shows no new issues vs. base branch
* CI pipeline passes

Made with [Cursor](https://cursor.com)